### PR TITLE
Support annotations in configmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Example yaml:
 ```
 name: foo
 namespace: system
+annotations:
+    strategy.spinnaker.io/versioned: false
 
 default:
   setting1: value1

--- a/config.go
+++ b/config.go
@@ -9,10 +9,11 @@ import (
 // Config represents a default ConfigMap
 // and any applicable overrides
 type Config struct {
-	Name      string                       `yaml:"name"`
-	Namespace string                       `yaml:"namespace"`
-	Default   map[string]string            `yaml:"default"`
-	Overrides map[string]map[string]string `yaml:"overrides"`
+	Name        string                       `yaml:"name"`
+	Namespace   string                       `yaml:"namespace"`
+	Default     map[string]string            `yaml:"default"`
+	Overrides   map[string]map[string]string `yaml:"overrides"`
+	Annotations map[string]string            `yaml:"annotations,omitempty"`
 }
 
 // NewConfigFromYaml reads yaml from a byte slice
@@ -32,8 +33,9 @@ func (c Config) OutputAll() map[string]v1.ConfigMap {
 
 	base := v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.Name,
-			Namespace: c.Namespace,
+			Name:        c.Name,
+			Namespace:   c.Namespace,
+			Annotations: c.Annotations,
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",

--- a/config_test.go
+++ b/config_test.go
@@ -34,6 +34,8 @@ func TestOutputsADefaultConfigMap(t *testing.T) {
 	require.Equal(t, "system", result.Namespace, "namespace did not fatch")
 	require.Equal(t, "value1", result.Data["setting1"], "setting1 did not match")
 	require.Equal(t, "value2", result.Data["setting2"], "setting1 did not match")
+	require.Equal(t, "value1", result.Annotations["key1"], "annotation1 did not match")
+	require.Equal(t, "value2", result.Annotations["key2"], "annotation2 did not match")
 
 }
 

--- a/example/all-envs.yaml
+++ b/example/all-envs.yaml
@@ -1,5 +1,8 @@
 name: foo
 namespace: system
+annotations:
+    key1: value1
+    key2: value2
 
 default:
   setting1: value1


### PR DESCRIPTION
Adds support for annotations in configurator-style config maps
'omitempty' on struct definition to make this an optional field