### PR TITLE
[PG-3] Add Codacy badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # k8s-configurator
+ 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/62d5e8eec18a40ccb620d0c3948c02f4)](https://app.codacy.com/gh/namely/k8s-configurator/dashboard)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/62d5e8eec18a40ccb620d0c3948c02f4)](https://app.codacy.com/gh/namely/k8s-configurator/dashboard)
 
 Generate environment-specific ConfigMaps from a single source Yaml.
 


### PR DESCRIPTION

# What does this do?

This PR adds the Codacy badges to the README.md

# Why are we doing this?

The Codacy badges provide an easy at-a-glance view of the code quality and coverage for the repository and increase awareness of quality goals.

Please drop in on the #codacy-discussion channel in Slack if you have any questions.